### PR TITLE
Update readsensors.ino

### DIFF
--- a/examples/readsensors/readsensors.ino
+++ b/examples/readsensors/readsensors.ino
@@ -15,7 +15,7 @@
 
 #define MAG_CONVERSION_16_BITS      (4912*2)/65535
 
-MPU9250 margSensor();
+MPU9250 margSensor;
 int16_t dataSensor[10]; //[NumSensors] (3gyros - 3 Accel - 1 Temp - 3 Mag)
 
 float


### PR DESCRIPTION
Para declarar variable margSensor en linea dieciocho, es necesito eliminar paréntesis cerca de margSensor. No hacerlo resultara en un error cuando utilizando este repositorio. Gracias.